### PR TITLE
cpu_bound

### DIFF
--- a/threads_cpu_bound.py
+++ b/threads_cpu_bound.py
@@ -1,0 +1,103 @@
+import threading
+import time
+import numpy as np
+import scipy.integrate as integrate
+
+
+def f(x):
+  return (x+1)**(1/2) + np.log(x)*x/5
+
+
+def integral(f, x, a : int, b : int): # по формуле левых прямоугольников
+  global ans
+  global locker
+  c = True
+  delta = abs(x[2]-x[1])
+  
+  for point in x:
+    if (point >= a) and (point <= b):
+      locker.acquire()
+      if c:
+        pred = point
+        c = False
+      else:
+        ans += delta*f(pred)
+        pred = point
+      locker.release()
+
+
+def integral2(f, x, a : int, b : int): # по формуле левых прямоугольников
+  global ans
+  global locker
+  c = True
+  delta = abs(x[2]-x[1])
+  locate = 0
+
+  for point in x:
+    if (point >= a) and (point <= b):
+      if c:
+        pred = point
+        c = False
+      else:
+        locate += delta*f(pred)
+        pred = point
+      
+  locker.acquire()
+  ans += locate
+  locker.release()
+
+    
+
+if __name__ == "__main__":
+    x = np.linspace(1, 100, 10**6)
+    ans = 0.0
+    locker = threading.RLock()
+    
+    res = integrate.quad(f, 1, 100)
+    time.sleep(2)
+    print(f"Истинное значение интеграла равно = {res[0]}")
+    print()
+
+    start = time.time()
+    integral(f, x, 1, 100)
+    print(f"Время выполнения одного потока = {time.time()-start}")
+    print(f"Результат выполнения одного потока = {ans}")
+    print()
+    
+    
+    n_mas = [3, 5, 10]
+    functions = [integral, integral2]
+
+    for func in functions:
+        if func == integral:
+           print("-----------------------------------------------")
+           print("СКОРОСТЬ ВЫЧИСЛЕНИЙ, КОГДА ГЛОБАЛЬНАЯ ПЕРЕМЕННАЯ(РЕЗУЛЬТАТ ИНТЕГРИРОВАНИЯ) ЯВЛЯЕТСЯ ОБЩЕЙ ДЛЯ ВСЕХ ПОТОКОВ")
+           print()
+        elif func == integral2:
+           print("-----------------------------------------------")
+           print("СКОРОСТЬ ВЫЧИСЛЕНИЙ, КОГДА СОЗДАЕТСЯ ЛОКАЛЬНАЯ ПЕРЕМЕННАЯ(РЕЗУЛЬТАТ ИНТЕГРИРОВАНИЯ) ДЛЯ КАЖДОГО ПОТОКА, И ЗАТЕМ ПОСЛЕ ВЫПОЛНЕНИЯ ЕЕ ЗНАЧЕНИЕ ПРИБАВЛЯЕТСЯ К ГЛОБАЛЬНОЙ ПЕРЕМЕННОЙ(ИТОГОВОМУ РКЗУЛЬТАТУ ИНТЕГРИРОВАНИЯ)")
+           print()
+        for n in n_mas:
+            ans = 0.0
+            mas_threads = []
+            length = 100 // n
+            b = 1
+            for i in range(n):
+                if i == (n-1):
+                    mas_threads.append(threading.Thread(target=func, args=(f, x, b, 100), name=f"thr-{i}", daemon=False))
+                else:
+                    buf = b
+                    b += length
+                    mas_threads.append(threading.Thread(target=func, args=(f, x, buf, b), name=f"thr-{i}", daemon=False))
+
+            start = time.time()
+            for thr in mas_threads:
+                thr.start()
+            for thr in mas_threads:
+                thr.join()
+            print(f"Время выполнения {n} потоков = {time.time()-start}")
+            print(f"Результат выполнения {n} потоков = {ans}")
+            print()
+
+
+


### PR DESCRIPTION
Рассмотрел многопоточность на примере вычислительной задачи интегрирования функции на заданном отрезке(от 1 до 100). Для каждого потока был выделен какой то отрезок меньшей длины на котором он считает интеграл исходной функции. При подсчете была создана глобальная переменная, в которую каждый поток по очереди вносил изменения, необходимо было также добавить объект синхронизации RLock, так как из за возникновения конфликтных ситуаций по данным итоговый результат не совпадал с истинным. По итогу времени на работу ушло больше из за накладных расходов.

Затем попробовал для каждого потока создавать локальную функцию, в которой подсчитывался результат интегрирования и затем после всех необходимых вычислений результат записывался в глобальную переменную, тем самым объекты синхронизации потоков не потребовались. Время работы уменьшилось по сравнению с предыдущей реализацией, но все равно немного больше, чем с одним потоком

Вывод: распараллеливать вычислительные задачи на питоне бессмысленно